### PR TITLE
Add multiple claims in JWT response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.15.0
+
+* Support for multiple sub-claims in OauthbearerOIDCApp JWT response.
+
 # 0.14.0
 
 * Support for metadata based authentication in OauthbearerOIDCApp.

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ for d in glob('trivup/apps/*App'):
                   if x[-1:] != '~']
 
 setup(name='trivup',
-      version='0.14.0',
+      version='0.15.0',
       description='Trivially Up a cluster of programs, such as a Kafka cluster',  # noqa: E501
       author='Magnus Edenhill',
       author_email='magnus@edenhill.se',

--- a/trivup/apps/OauthbearerOIDCApp.py
+++ b/trivup/apps/OauthbearerOIDCApp.py
@@ -177,7 +177,8 @@ class WebServerHandler(BaseHTTPRequestHandler):
             'iat': now,
             'iss': "issuer",
             'sub': "subject",
-            'aud': 'api://default'
+            'aud': 'api://default',
+            'client_id': "subject"
         }
         header = {
             "kid": "abcdefg",


### PR DESCRIPTION
### Existing Behavior

The trivup setup used to generate JWT with only `"sub"` claim in the response. 

### Requirement
We are adding a config parameter to provide a custom claim (client_id). If this parameter is set the JWT should contain that additional claim as well. To keep it simple, we always want the JWT to return multiple claims (`"sub"` and `"client_id"`). This would help us to verify all the client side validations for JWT parsing.

### New Behavior
Trivup setup now always generates a JWT with `"sub"` and `"client_id"` in the response.